### PR TITLE
Patch Version 2.4.1 Dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7510,9 +7510,9 @@
             "dev": true
         },
         "ssri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+            "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
             "dev": true,
             "requires": {
                 "figgy-pudding": "^3.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3455,15 +3455,36 @@
             }
         },
         "browserslist": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
-            "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001043",
-                "electron-to-chromium": "^1.3.413",
-                "node-releases": "^1.1.53",
-                "pkg-up": "^2.0.0"
+                "caniuse-lite": "^1.0.30001219",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.723",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.71"
+            },
+            "dependencies": {
+                "caniuse-lite": {
+                    "version": "1.0.30001230",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+                    "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.739",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+                    "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "1.1.72",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+                    "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+                    "dev": true
+                }
             }
         },
         "buffer": {
@@ -3608,12 +3629,6 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true
-        },
-        "caniuse-lite": {
-            "version": "1.0.30001062",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001062.tgz",
-            "integrity": "sha512-ei9ZqeOnN7edDrb24QfJ0OZicpEbsWxv7WusOiQGz/f2SfvBgHHbOEwBJ8HKGVSyx8Z6ndPjxzR6m0NQq+0bfw==",
             "dev": true
         },
         "chalk": {
@@ -3806,6 +3821,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
             "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+            "dev": true
+        },
+        "colorette": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
         "commander": {
@@ -4150,12 +4171,6 @@
                 "stream-shift": "^1.0.0"
             }
         },
-        "electron-to-chromium": {
-            "version": "1.3.446",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.446.tgz",
-            "integrity": "sha512-CLQaFuvkKqR9FD2G3cJrr1fV7DRMXiAKWLP2F8cxtvvtzAS7Tubt0kF47/m+uE61kiT+I7ZEn7HqLnmWdOhmuA==",
-            "dev": true
-        },
         "elliptic": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
@@ -4211,6 +4226,12 @@
             "requires": {
                 "prr": "~1.0.1"
             }
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -6417,12 +6438,6 @@
             "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
             "dev": true
         },
-        "node-releases": {
-            "version": "1.1.56",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.56.tgz",
-            "integrity": "sha512-EVo605FhWLygH8a64TjgpjyHYOihkxECwX1bHHr8tETJKWEiWS2YJjPbvsX2jFjnjTNEgBCmk9mLjKG1Mf11cw==",
-            "dev": true
-        },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -6753,60 +6768,6 @@
             "dev": true,
             "requires": {
                 "find-up": "^3.0.0"
-            }
-        },
-        "pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-            "dev": true,
-            "requires": {
-                "find-up": "^2.1.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^2.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^1.1.0"
-                    }
-                },
-                "p-try": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-                    "dev": true
-                }
             }
         },
         "pluralize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,12 +685,6 @@
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
                 }
             }
         },
@@ -2519,12 +2513,6 @@
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.15",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-                    "dev": true
                 },
                 "make-dir": {
                     "version": "2.1.0",
@@ -6065,9 +6053,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "loose-envify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4160,18 +4160,32 @@
             }
         },
         "elliptic": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
                 "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                }
             }
         },
         "emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8402,9 +8402,9 @@
             "dev": true
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
             "dev": true
         },
         "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4985,12 +4985,6 @@
                     "dev": true,
                     "optional": true
                 },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
@@ -5679,9 +5673,9 @@
             "dev": true
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
         "inquirer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "humanapi-connect-client",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "devDependencies": {
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.6",


### PR DESCRIPTION
Applies dependabot updates.

- chore(deps): bump browserslist from 4.12.0 to 4.16.6
- chore(deps): bump lodash from 4.17.15 to 4.17.21
- chore(deps): bump ssri from 6.0.1 to 6.0.2
- chore(deps): bump y18n from 4.0.0 to 4.0.1
- chore(deps): bump elliptic from 6.5.2 to 6.5.4
- chore(deps): bump ini from 1.3.5 to 1.3.8